### PR TITLE
PEP 8 Formatting for Private Methods

### DIFF
--- a/benzinga/__init__.py
+++ b/benzinga/__init__.py
@@ -1,3 +1,2 @@
 from .financial_data import Benzinga
 from .news_data import News
-from .param_check import Param_Check

--- a/benzinga/financial_data.py
+++ b/benzinga/financial_data.py
@@ -21,7 +21,7 @@ class Benzinga:
         }
         self.param_initiate = param_check.Param_Check()
 
-    def __token_check__(self, api_token):
+    def _token_check(self, api_token):
         """Private Method: Token check is a private method that does a basic check for whether the api token has
         access to the fundamentals and/or calendar data. Different tokens have access to different endpoints.
         Disregard the error if your request is fullfilled but the token authentication error is raised.
@@ -40,12 +40,12 @@ class Benzinga:
             'parameters[tickers]': company_ticker
         }
 
-        ratingsUrl = self.__url_call__("calendar", "dividends")
+        ratingsUrl = self._url_call("calendar", "dividends")
         ratings = requests.get(ratingsUrl, headers=self.headers, params=params)
         if ratings.status_code == 401:
             raise TokenAuthenticationError
 
-    def __url_call__(self, resource, sub_resource=""):
+    def _url_call(self, resource, sub_resource=""):
         """Private Method: URL Call is used to take input from the public methods and return the appropriate url format
         for the endpoint. For example, the resource is calendar and the subresource might be ratings. The correct
         url endpoint call is created by using these two.
@@ -95,7 +95,7 @@ class Benzinga:
         }
         self.param_initiate.batchhistory_check(params)
         try:
-            batchhistory_url = self.__url_call__("batchhistory")
+            batchhistory_url = self._url_call("batchhistory")
             batchhistory = requests.get(batchhistory_url, headers=self.headers, params=params)
             if batchhistory.status_code == 401:
                 raise TokenAuthenticationError
@@ -130,7 +130,7 @@ class Benzinga:
         }
         self.param_initiate.autocomplete_check(params)
         try:
-            autocomplete_url = self.__url_call__("autocomplete")
+            autocomplete_url = self._url_call("autocomplete")
             autocomplete = requests.get(autocomplete_url, headers=self.headers, params=params)
             if autocomplete.status_code == 401:
                 raise TokenAuthenticationError
@@ -156,7 +156,7 @@ class Benzinga:
         }
         self.param_initiate.security_check(params)
         try:
-            security_url = self.__url_call__("security")
+            security_url = self._url_call("security")
             security = requests.get(security_url, headers=self.headers, params=params)
             if security.status_code == 401:
                 raise TokenAuthenticationError
@@ -188,7 +188,7 @@ class Benzinga:
         }
         self.param_initiate.charts_check(params)
         try:
-            chart_url = self.__url_call__("chart")
+            chart_url = self._url_call("chart")
             chart = requests.get(chart_url, headers=self.headers, params=params)
             if chart.status_code == 401:
                 raise TokenAuthenticationError
@@ -216,7 +216,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            quote_url = self.__url_call__("quote")
+            quote_url = self._url_call("quote")
             quote = requests.get(quote_url, headers=self.headers, params=params)
             if quote.status_code == 401:
                 raise TokenAuthenticationError
@@ -279,7 +279,7 @@ class Benzinga:
         }
         self.param_initiate.instruments_check(params)
         try:
-            instruments_url = self.__url_call__("instruments")
+            instruments_url = self._url_call("instruments")
             instruments = requests.get(instruments_url, headers=self.headers, params=params)
             if instruments.status_code == 401:
                 raise TokenAuthenticationError
@@ -330,7 +330,7 @@ class Benzinga:
         }
         self.param_initiate.calendar_check(params)
         try:
-            dividends_url = self.__url_call__("calendar", "dividends")
+            dividends_url = self._url_call("calendar", "dividends")
             dividends = requests.get(dividends_url, headers=self.headers, params=params)
             if dividends.status_code == 401:
                 raise AccessDeniedError
@@ -377,7 +377,7 @@ class Benzinga:
         }
         self.param_initiate.calendar_check(params)
         try:
-            earnings_url = self.__url_call__("calendar", "earnings")
+            earnings_url = self._url_call("calendar", "earnings")
             earnings = requests.get(earnings_url, headers=self.headers, params=params)
             if earnings.status_code == 401:
                 raise TokenAuthenticationError
@@ -420,7 +420,7 @@ class Benzinga:
         }
         self.param_initiate.calendar_check(params)
         try:
-            splits_url = self.__url_call__("calendar", "splits")
+            splits_url = self._url_call("calendar", "splits")
             splits = requests.get(splits_url, headers=self.headers, params=params)
             if splits.status_code == 401:
                 raise TokenAuthenticationError
@@ -464,7 +464,7 @@ class Benzinga:
         }
         self.param_initiate.calendar_check(params)
         try:
-            economics_url = self.__url_call__("calendar", "economics")
+            economics_url = self._url_call("calendar", "economics")
             economics = requests.get(economics_url, headers=self.headers, params=params)
             if economics.status_code == 401:
                 raise TokenAuthenticationError
@@ -510,7 +510,7 @@ class Benzinga:
         }
         self.param_initiate.calendar_check(params)
         try:
-            guidance_url = self.__url_call__("calendar", "guidance")
+            guidance_url = self._url_call("calendar", "guidance")
             guidance = requests.get(guidance_url, headers=self.headers, params=params)
             if guidance.status_code == 401:
                 raise TokenAuthenticationError
@@ -554,7 +554,7 @@ class Benzinga:
         }
         self.param_initiate.calendar_check(params)
         try:
-            ipo_url = self.__url_call__("calendar", "ipos")
+            ipo_url = self._url_call("calendar", "ipos")
             ipo = requests.get(ipo_url, headers=self.headers, params=params)
             if ipo.status_code == 401:
                 raise TokenAuthenticationError
@@ -598,7 +598,7 @@ class Benzinga:
 
         self.param_initiate.calendar_check(params)
         try:
-            retail_url = self.__url_call__("calendar", "retail")
+            retail_url = self._url_call("calendar", "retail")
             retail = requests.get(retail_url, headers=self.headers, params=params)
             if retail.status_code == 401:
                 raise TokenAuthenticationError
@@ -646,7 +646,7 @@ class Benzinga:
 
         self.param_initiate.calendar_check(params)
         try:
-            ratings_url = self.__url_call__("calendar", "ratings")
+            ratings_url = self._url_call("calendar", "ratings")
             ratings = requests.get(ratings_url, headers=self.headers, params=params)
             if ratings.status_code == 401:
                 raise TokenAuthenticationError
@@ -689,7 +689,7 @@ class Benzinga:
         }
         self.param_initiate.calendar_check(params)
         try:
-            conference_url = self.__url_call__("calendar", "conference-calls")
+            conference_url = self._url_call("calendar", "conference-calls")
             conference = requests.get(conference_url, headers=self.headers, params=params)
             if conference.status_code == 401:
                 raise TokenAuthenticationError
@@ -720,7 +720,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            financials_url = self.__url_call__("fundamentals")
+            financials_url = self._url_call("fundamentals")
             financials = requests.get(financials_url, headers=self.headers, params= params)
             if financials.status_code == 401:
                 raise TokenAuthenticationError
@@ -756,7 +756,7 @@ class Benzinga:
 
         self.param_initiate.fundamentals_check(params)
         try:
-            financials_url = self.__url_call__("fundamentals", "financials")
+            financials_url = self._url_call("fundamentals", "financials")
             financials = requests.get(financials_url, headers=self.headers, params= params)
             if financials.status_code == 401:
                 raise TokenAuthenticationError
@@ -786,7 +786,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            valuation_url = self.__url_call__("fundamentals", "valuationRatios")
+            valuation_url = self._url_call("fundamentals", "valuationRatios")
             valuation = requests.get(valuation_url, headers=self.headers, params=params)
             if valuation.status_code == 401:
                 raise TokenAuthenticationError
@@ -815,7 +815,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            earnings_url = self.__url_call__("fundamentals", "earningRatios")
+            earnings_url = self._url_call("fundamentals", "earningRatios")
             earnings = requests.get(earnings_url, headers=self.headers, params=params)
             if earnings.status_code == 401:
                 raise TokenAuthenticationError
@@ -844,7 +844,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            operations_url = self.__url_call__("fundamentals", "operationRatios")
+            operations_url = self._url_call("fundamentals", "operationRatios")
             operations = requests.get(operations_url, headers=self.headers, params= params)
         except requests.exceptions.RequestException:
             raise AccessDeniedError
@@ -872,7 +872,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            shareclass_url = self.__url_call__("fundamentals", "shareClass")
+            shareclass_url = self._url_call("fundamentals", "shareClass")
             shareclass = requests.get(shareclass_url, headers=self.headers, params= params)
             if shareclass.status_code == 401:
                 raise TokenAuthenticationError
@@ -901,7 +901,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            earningreports_url = self.__url_call__("fundamentals", "earningReports")
+            earningreports_url = self._url_call("fundamentals", "earningReports")
             earningreports = requests.get(earningreports_url, headers=self.headers, params= params)
             if earningreports.status_code == 401:
                 raise TokenAuthenticationError
@@ -930,7 +930,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            alphabeta_url = self.__url_call__("fundamentals", "alphaBeta")
+            alphabeta_url = self._url_call("fundamentals", "alphaBeta")
             alphabeta = requests.get(alphabeta_url, headers=self.headers, params= params)
             if alphabeta.status_code == 401:
                 raise TokenAuthenticationError
@@ -959,7 +959,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            companyprofile_url = self.__url_call__("fundamentals", "companyProfile")
+            companyprofile_url = self._url_call("fundamentals", "companyProfile")
             company_profile = requests.get(companyprofile_url, headers=self.headers, params= params)
             if company_profile.status_code == 401:
                 raise TokenAuthenticationError
@@ -988,7 +988,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            company_url = self.__url_call__("fundamentals", "company")
+            company_url = self._url_call("fundamentals", "company")
             company = requests.get(company_url, headers=self.headers, params= params)
             if company.status_code == 401:
                 raise TokenAuthenticationError
@@ -1017,7 +1017,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            profilehistory_url = self.__url_call__("fundamentals", "shareClassProfileHistory")
+            profilehistory_url = self._url_call("fundamentals", "shareClassProfileHistory")
             profilehistory = requests.get(profilehistory_url, headers=self.headers, params= params)
             if profilehistory.status_code == 401:
                 raise TokenAuthenticationError
@@ -1046,7 +1046,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            asset_url = self.__url_call__("fundamentals", "assetClassification")
+            asset_url = self._url_call("fundamentals", "assetClassification")
             asset = requests.get(asset_url, headers=self.headers, params= params)
             if asset.status_code == 401:
                 raise TokenAuthenticationError
@@ -1075,7 +1075,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            summary_url = self.__url_call__("ownership", "summary")
+            summary_url = self._url_call("ownership", "summary")
             summary = requests.get(summary_url, headers=self.headers, params= params)
             if summary.status_code == 401:
                 raise TokenAuthenticationError
@@ -1099,7 +1099,7 @@ class Benzinga:
         }
         self.param_initiate.ticker_check(params)
         try:
-            ticker_url = self.__url_call__("tickerDetail")
+            ticker_url = self._url_call("tickerDetail")
             ticker = requests.get(ticker_url, headers=self.headers, params= params)
             if ticker.status_code == 401:
                 raise TokenAuthenticationError
@@ -1125,7 +1125,7 @@ class Benzinga:
         }
         self.param_initiate.logos_check(params)
         try:
-            logos_url = self.__url_call__("logos")
+            logos_url = self._url_call("logos")
             logos = requests.get(logos_url, headers = self.headers, params=params)
             if logos.status_code == 401:
                 raise TokenAuthenticationError
@@ -1182,7 +1182,7 @@ class Benzinga:
         }
         self.param_initiate.movers_check(params)
         try:
-            movers_url = self.__url_call__("movers")
+            movers_url = self._url_call("movers")
             movers = requests.get(movers_url, headers=self.headers, params=params)
             if movers.status_code == 401:
                 raise TokenAuthenticationError

--- a/benzinga/financial_data.py
+++ b/benzinga/financial_data.py
@@ -1,9 +1,8 @@
 import requests, json
 import datetime as dt
-from param_check import Param_Check
+import param_check
 from benzinga_errors import (TokenAuthenticationError, RequestAPIEndpointError, IncorrectParameterEntry,
                              URLIncorrectlyFormattedError, MissingParameter, AccessDeniedError)
-
 
 class Benzinga: 
 
@@ -20,7 +19,7 @@ class Benzinga:
             "Data api v2": "https://api.benzinga.io/dataapi/rest/v2/",
             "API rest": "https://data.benzinga.com/quote-store/api/"
         }
-        self.param_initiate = Param_Check()
+        self.param_initiate = param_check.Param_Check()
 
     def __token_check__(self, api_token):
         """Private Method: Token check is a private method that does a basic check for whether the api token has
@@ -1134,15 +1133,15 @@ class Benzinga:
             raise AccessDeniedError
         return logos.json()
 
-    def movers(self, session = "REGULAR", interval = None, date_asof = None, max_results = None,
+    def movers(self, session = "REGULAR", date_from = None, date_to = None, max_results = None,
                market_cap_gt = None, close_gt = None, sector = None, market_cap_lt = None):
         """Public Method: Movers Data on Gainers and Losers
 
               Arguments:
                   Optional:
                       session (str) - "PRE_MARKET, REGULAR, AFTER_MARKET
-                      interval (str) - "YTD" or "-1W" etc.
-                      date_asof (str) - "YYYY-MM-DD" default is the most recent timestamp
+                      date_from (str) - "YYYY-MM-DD"
+                      date_to (str) - "YYYY-MM-DD" default is the most recent timestamp
                       max_results (int) - default 10
                       market_cap_gt (str) - market cap greater than "1b" etc
                       market_cap_lt (str) - market cap less than "1b" etc
@@ -1175,8 +1174,8 @@ class Benzinga:
             screener_query = "%s%s%s%s"% (market_cap_greater, marketcap_less, close_greater,sector)
         params = {
             "apikey": self.token,
-            "from": interval,
-            "to": date_asof,
+            "from": date_from,
+            "to": date_to,
             "session": session,
             "screenerQuery": screener_query,
             "maxResults": max_results

--- a/benzinga/news_data.py
+++ b/benzinga/news_data.py
@@ -11,10 +11,10 @@ class News:
         self.headers = {'accept': 'application/json'}
         self.url_dict = {"API V2": "http://api.benzinga.com/api/v2/"}
 
-        self.__token_check__(self.token)
+        self._token_check(self.token)
         self.param_initiate = param_check.Param_Check()
 
-    def __token_check__(self, api_token):
+    def _token_check(self, api_token):
         """Private Method: Token check is a private method that does a basic check for whether the api token has
                access to the fundamentals and/or calendar data. Different tokens have access to different endpoints.
                Disregard the error if your request is fullfilled but the token authentication error is raised.
@@ -26,14 +26,14 @@ class News:
                 Token authentication error if token is invalid."""
         params = {'token': api_token}
         try:
-            sample_url = self.__url_call__("news")
+            sample_url = self._url_call("news")
             sample = requests.get(sample_url, headers= self.headers, params=params)
             if sample.status_code == 401:
                 raise TokenAuthenticationError
         except TokenAuthenticationError as t:
             raise AccessDeniedError
 
-    def __url_call__(self, resource, sub_resource=""):
+    def _url_call(self, resource, sub_resource=""):
         """Private Method: URL Call is used to take input from the public methods and return the appropriate url format
                 for the endpoint. For example, the resource is calendar and the subresource might be ratings. The correct
                 url endpoint call is created by using these two.
@@ -94,7 +94,7 @@ class News:
         }
         self.param_initiate.news_check(params)
         try:
-            news_url = self.__url_call__("news")
+            news_url = self._url_call("news")
             news = requests.get(news_url, headers=self.headers, params=params)
             if news.status_code == 401:
                 raise TokenAuthenticationError
@@ -124,7 +124,7 @@ class News:
         }
         self.param_initiate.news_check(params)
         try:
-            top_news_url = self.__url_call__("news-top-stories")
+            top_news_url = self._url_call("news-top-stories")
             top_news = requests.get(top_news_url, headers=self.headers, params=params)
             if top_news.status_code == 401:
                 raise TokenAuthenticationError
@@ -173,7 +173,7 @@ class News:
         }
         self.param_initiate.news_check(params)
         try:
-            channels_url = self.__url_call__("channels")
+            channels_url = self._url_call("channels")
             channels = requests.get(channels_url, headers=self.headers, params=params)
             if channels.status_code == 401:
                 raise TokenAuthenticationError
@@ -211,7 +211,7 @@ class News:
         }
         self.param_initiate.quantified_news_check(params)
         try:
-            quantnews_url = self.__url_call__("newsquantified")
+            quantnews_url = self._url_call("newsquantified")
             quantnews = requests.get(quantnews_url, headers=self.headers, params=params)
             if quantnews.status_code == 401:
                 raise TokenAuthenticationError

--- a/benzinga/param_check.py
+++ b/benzinga/param_check.py
@@ -8,7 +8,7 @@ class Param_Check:
         self.nonetype = "NoneType"
         self.float = "float"
 
-    def __para_type_matching__(self, param_metadata, para_dict):
+    def _para_type_matching(self, param_metadata, para_dict):
         for param, value in para_dict.items():
             if (type(value).__name__ != param_metadata[param]) and (type(value).__name__ != self.nonetype):
                 raise IncorrectParameterEntry("Parameter Type for %s doesn't match: Correct Type: %s. " 
@@ -34,7 +34,7 @@ class Param_Check:
             "parameters[eps_surprise_percent]": self.stri,
             "parameters[revenue_surprise_percent]": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def fundamentals_check(self, dict):
         param_type = {
@@ -47,7 +47,7 @@ class Param_Check:
             "period": self.stri,
             "reportType": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def delayed_quote_check(self, dict):
         param_type = {
@@ -56,7 +56,7 @@ class Param_Check:
             "isin": self.stri,
             "cik": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def logos_check(self, dict):
         param_type = {
@@ -64,7 +64,7 @@ class Param_Check:
             "symbols": self.stri,
             "filters": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def instruments_check(self, dict):
         param_type = {
@@ -77,7 +77,7 @@ class Param_Check:
             "sortfield": self.stri,
             "sortdir": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def security_check(self, dict):
         param_type = {
@@ -85,7 +85,7 @@ class Param_Check:
             "symbol": self.stri,
             "cusip": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def charts_check(self, dict):
         param_type = {
@@ -96,14 +96,14 @@ class Param_Check:
             "interval": self.stri,
             "session": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def ticker_check(self, dict):
         param_type = {
             "apikey": self.stri,
             "symbols": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
     def autocomplete_check(self, dict):
         param_type = {
             "token": self.stri,
@@ -113,14 +113,14 @@ class Param_Check:
             "exchanges": self.stri,
             "types": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def batchhistory_check(self, dict):
         param_type = {
             "apikey": self.stri,
             "symbol": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def news_check(self, dict):
         param_type = {
@@ -140,7 +140,7 @@ class Param_Check:
             "limit": self.inte,
             "channel": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def quantified_news_check(self, dict):
         param_type = {
@@ -154,7 +154,7 @@ class Param_Check:
             "symbols": self.stri,
             "apikey": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def movers_check(self, dict):
         param_type = {
@@ -165,7 +165,7 @@ class Param_Check:
             "maxResults": self.stri,
             "screenerQuery":self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
 
 

--- a/benzinga/tests.py
+++ b/benzinga/tests.py
@@ -1,10 +1,7 @@
 import financial_data
 import news_data
 
-token = "899efcbfda344e089b23589cbddac62b"
-api_key = "22f84f867c5746fd92ef8e13f5835c02"
-newapikey = "54b595f497164e0499409ca93342e394"
-
+token = input("Enter your API Key:")
 company_tickers = "AAPL"
 start_date = "2018-05-01"
 end_date = "2006-09-12"
@@ -15,4 +12,3 @@ data = financial_data.Benzinga(token)
 """Sample Run News API"""
 news = news_data.News(token)
 
-print(data.output(data.movers(session = "REGULAR", sector = "healthcare", max_results = "100", interval= "YTD")))

--- a/build/lib/benzinga/__init__.py
+++ b/build/lib/benzinga/__init__.py
@@ -1,3 +1,2 @@
 from .financial_data import Benzinga
 from .news_data import News
-from .param_check import Param_Check

--- a/build/lib/benzinga/financial_data.py
+++ b/build/lib/benzinga/financial_data.py
@@ -1,6 +1,6 @@
 import requests, json
 import datetime as dt
-from param_check import Param_Check
+import param_check
 from benzinga_errors import (TokenAuthenticationError, RequestAPIEndpointError, IncorrectParameterEntry,
                              URLIncorrectlyFormattedError, MissingParameter, AccessDeniedError)
 
@@ -19,9 +19,9 @@ class Benzinga:
             "Data api v2": "https://api.benzinga.io/dataapi/rest/v2/",
             "API rest": "https://data.benzinga.com/quote-store/api/"
         }
-        self.param_initiate = Param_Check()
+        self.param_initiate = param_check.Param_Check()
 
-    def __token_check__(self, api_token):
+    def _token_check(self, api_token):
         """Private Method: Token check is a private method that does a basic check for whether the api token has
         access to the fundamentals and/or calendar data. Different tokens have access to different endpoints.
         Disregard the error if your request is fullfilled but the token authentication error is raised.
@@ -40,12 +40,12 @@ class Benzinga:
             'parameters[tickers]': company_ticker
         }
 
-        ratingsUrl = self.__url_call__("calendar", "dividends")
+        ratingsUrl = self._url_call("calendar", "dividends")
         ratings = requests.get(ratingsUrl, headers=self.headers, params=params)
         if ratings.status_code == 401:
             raise TokenAuthenticationError
 
-    def __url_call__(self, resource, sub_resource=""):
+    def _url_call(self, resource, sub_resource=""):
         """Private Method: URL Call is used to take input from the public methods and return the appropriate url format
         for the endpoint. For example, the resource is calendar and the subresource might be ratings. The correct
         url endpoint call is created by using these two.
@@ -95,7 +95,7 @@ class Benzinga:
         }
         self.param_initiate.batchhistory_check(params)
         try:
-            batchhistory_url = self.__url_call__("batchhistory")
+            batchhistory_url = self._url_call("batchhistory")
             batchhistory = requests.get(batchhistory_url, headers=self.headers, params=params)
             if batchhistory.status_code == 401:
                 raise TokenAuthenticationError
@@ -130,7 +130,7 @@ class Benzinga:
         }
         self.param_initiate.autocomplete_check(params)
         try:
-            autocomplete_url = self.__url_call__("autocomplete")
+            autocomplete_url = self._url_call("autocomplete")
             autocomplete = requests.get(autocomplete_url, headers=self.headers, params=params)
             if autocomplete.status_code == 401:
                 raise TokenAuthenticationError
@@ -156,7 +156,7 @@ class Benzinga:
         }
         self.param_initiate.security_check(params)
         try:
-            security_url = self.__url_call__("security")
+            security_url = self._url_call("security")
             security = requests.get(security_url, headers=self.headers, params=params)
             if security.status_code == 401:
                 raise TokenAuthenticationError
@@ -188,7 +188,7 @@ class Benzinga:
         }
         self.param_initiate.charts_check(params)
         try:
-            chart_url = self.__url_call__("chart")
+            chart_url = self._url_call("chart")
             chart = requests.get(chart_url, headers=self.headers, params=params)
             if chart.status_code == 401:
                 raise TokenAuthenticationError
@@ -216,7 +216,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            quote_url = self.__url_call__("quote")
+            quote_url = self._url_call("quote")
             quote = requests.get(quote_url, headers=self.headers, params=params)
             if quote.status_code == 401:
                 raise TokenAuthenticationError
@@ -279,7 +279,7 @@ class Benzinga:
         }
         self.param_initiate.instruments_check(params)
         try:
-            instruments_url = self.__url_call__("instruments")
+            instruments_url = self._url_call("instruments")
             instruments = requests.get(instruments_url, headers=self.headers, params=params)
             if instruments.status_code == 401:
                 raise TokenAuthenticationError
@@ -330,7 +330,7 @@ class Benzinga:
         }
         self.param_initiate.calendar_check(params)
         try:
-            dividends_url = self.__url_call__("calendar", "dividends")
+            dividends_url = self._url_call("calendar", "dividends")
             dividends = requests.get(dividends_url, headers=self.headers, params=params)
             if dividends.status_code == 401:
                 raise AccessDeniedError
@@ -377,7 +377,7 @@ class Benzinga:
         }
         self.param_initiate.calendar_check(params)
         try:
-            earnings_url = self.__url_call__("calendar", "earnings")
+            earnings_url = self._url_call("calendar", "earnings")
             earnings = requests.get(earnings_url, headers=self.headers, params=params)
             if earnings.status_code == 401:
                 raise TokenAuthenticationError
@@ -420,7 +420,7 @@ class Benzinga:
         }
         self.param_initiate.calendar_check(params)
         try:
-            splits_url = self.__url_call__("calendar", "splits")
+            splits_url = self._url_call("calendar", "splits")
             splits = requests.get(splits_url, headers=self.headers, params=params)
             if splits.status_code == 401:
                 raise TokenAuthenticationError
@@ -464,7 +464,7 @@ class Benzinga:
         }
         self.param_initiate.calendar_check(params)
         try:
-            economics_url = self.__url_call__("calendar", "economics")
+            economics_url = self._url_call("calendar", "economics")
             economics = requests.get(economics_url, headers=self.headers, params=params)
             if economics.status_code == 401:
                 raise TokenAuthenticationError
@@ -510,7 +510,7 @@ class Benzinga:
         }
         self.param_initiate.calendar_check(params)
         try:
-            guidance_url = self.__url_call__("calendar", "guidance")
+            guidance_url = self._url_call("calendar", "guidance")
             guidance = requests.get(guidance_url, headers=self.headers, params=params)
             if guidance.status_code == 401:
                 raise TokenAuthenticationError
@@ -554,7 +554,7 @@ class Benzinga:
         }
         self.param_initiate.calendar_check(params)
         try:
-            ipo_url = self.__url_call__("calendar", "ipos")
+            ipo_url = self._url_call("calendar", "ipos")
             ipo = requests.get(ipo_url, headers=self.headers, params=params)
             if ipo.status_code == 401:
                 raise TokenAuthenticationError
@@ -598,7 +598,7 @@ class Benzinga:
 
         self.param_initiate.calendar_check(params)
         try:
-            retail_url = self.__url_call__("calendar", "retail")
+            retail_url = self._url_call("calendar", "retail")
             retail = requests.get(retail_url, headers=self.headers, params=params)
             if retail.status_code == 401:
                 raise TokenAuthenticationError
@@ -646,7 +646,7 @@ class Benzinga:
 
         self.param_initiate.calendar_check(params)
         try:
-            ratings_url = self.__url_call__("calendar", "ratings")
+            ratings_url = self._url_call("calendar", "ratings")
             ratings = requests.get(ratings_url, headers=self.headers, params=params)
             if ratings.status_code == 401:
                 raise TokenAuthenticationError
@@ -689,7 +689,7 @@ class Benzinga:
         }
         self.param_initiate.calendar_check(params)
         try:
-            conference_url = self.__url_call__("calendar", "conference-calls")
+            conference_url = self._url_call("calendar", "conference-calls")
             conference = requests.get(conference_url, headers=self.headers, params=params)
             if conference.status_code == 401:
                 raise TokenAuthenticationError
@@ -720,7 +720,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            financials_url = self.__url_call__("fundamentals")
+            financials_url = self._url_call("fundamentals")
             financials = requests.get(financials_url, headers=self.headers, params= params)
             if financials.status_code == 401:
                 raise TokenAuthenticationError
@@ -756,7 +756,7 @@ class Benzinga:
 
         self.param_initiate.fundamentals_check(params)
         try:
-            financials_url = self.__url_call__("fundamentals", "financials")
+            financials_url = self._url_call("fundamentals", "financials")
             financials = requests.get(financials_url, headers=self.headers, params= params)
             if financials.status_code == 401:
                 raise TokenAuthenticationError
@@ -786,7 +786,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            valuation_url = self.__url_call__("fundamentals", "valuationRatios")
+            valuation_url = self._url_call("fundamentals", "valuationRatios")
             valuation = requests.get(valuation_url, headers=self.headers, params=params)
             if valuation.status_code == 401:
                 raise TokenAuthenticationError
@@ -815,7 +815,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            earnings_url = self.__url_call__("fundamentals", "earningRatios")
+            earnings_url = self._url_call("fundamentals", "earningRatios")
             earnings = requests.get(earnings_url, headers=self.headers, params=params)
             if earnings.status_code == 401:
                 raise TokenAuthenticationError
@@ -844,7 +844,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            operations_url = self.__url_call__("fundamentals", "operationRatios")
+            operations_url = self._url_call("fundamentals", "operationRatios")
             operations = requests.get(operations_url, headers=self.headers, params= params)
         except requests.exceptions.RequestException:
             raise AccessDeniedError
@@ -872,7 +872,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            shareclass_url = self.__url_call__("fundamentals", "shareClass")
+            shareclass_url = self._url_call("fundamentals", "shareClass")
             shareclass = requests.get(shareclass_url, headers=self.headers, params= params)
             if shareclass.status_code == 401:
                 raise TokenAuthenticationError
@@ -901,7 +901,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            earningreports_url = self.__url_call__("fundamentals", "earningReports")
+            earningreports_url = self._url_call("fundamentals", "earningReports")
             earningreports = requests.get(earningreports_url, headers=self.headers, params= params)
             if earningreports.status_code == 401:
                 raise TokenAuthenticationError
@@ -930,7 +930,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            alphabeta_url = self.__url_call__("fundamentals", "alphaBeta")
+            alphabeta_url = self._url_call("fundamentals", "alphaBeta")
             alphabeta = requests.get(alphabeta_url, headers=self.headers, params= params)
             if alphabeta.status_code == 401:
                 raise TokenAuthenticationError
@@ -959,7 +959,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            companyprofile_url = self.__url_call__("fundamentals", "companyProfile")
+            companyprofile_url = self._url_call("fundamentals", "companyProfile")
             company_profile = requests.get(companyprofile_url, headers=self.headers, params= params)
             if company_profile.status_code == 401:
                 raise TokenAuthenticationError
@@ -988,7 +988,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            company_url = self.__url_call__("fundamentals", "company")
+            company_url = self._url_call("fundamentals", "company")
             company = requests.get(company_url, headers=self.headers, params= params)
             if company.status_code == 401:
                 raise TokenAuthenticationError
@@ -1017,7 +1017,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            profilehistory_url = self.__url_call__("fundamentals", "shareClassProfileHistory")
+            profilehistory_url = self._url_call("fundamentals", "shareClassProfileHistory")
             profilehistory = requests.get(profilehistory_url, headers=self.headers, params= params)
             if profilehistory.status_code == 401:
                 raise TokenAuthenticationError
@@ -1046,7 +1046,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            asset_url = self.__url_call__("fundamentals", "assetClassification")
+            asset_url = self._url_call("fundamentals", "assetClassification")
             asset = requests.get(asset_url, headers=self.headers, params= params)
             if asset.status_code == 401:
                 raise TokenAuthenticationError
@@ -1075,7 +1075,7 @@ class Benzinga:
         }
         self.param_initiate.fundamentals_check(params)
         try:
-            summary_url = self.__url_call__("ownership", "summary")
+            summary_url = self._url_call("ownership", "summary")
             summary = requests.get(summary_url, headers=self.headers, params= params)
             if summary.status_code == 401:
                 raise TokenAuthenticationError
@@ -1099,7 +1099,7 @@ class Benzinga:
         }
         self.param_initiate.ticker_check(params)
         try:
-            ticker_url = self.__url_call__("tickerDetail")
+            ticker_url = self._url_call("tickerDetail")
             ticker = requests.get(ticker_url, headers=self.headers, params= params)
             if ticker.status_code == 401:
                 raise TokenAuthenticationError
@@ -1125,7 +1125,7 @@ class Benzinga:
         }
         self.param_initiate.logos_check(params)
         try:
-            logos_url = self.__url_call__("logos")
+            logos_url = self._url_call("logos")
             logos = requests.get(logos_url, headers = self.headers, params=params)
             if logos.status_code == 401:
                 raise TokenAuthenticationError
@@ -1133,15 +1133,15 @@ class Benzinga:
             raise AccessDeniedError
         return logos.json()
 
-    def movers(self, session = "REGULAR", interval = None, date_asof = None, max_results = None,
+    def movers(self, session = "REGULAR", date_from = None, date_to = None, max_results = None,
                market_cap_gt = None, close_gt = None, sector = None, market_cap_lt = None):
         """Public Method: Movers Data on Gainers and Losers
 
               Arguments:
                   Optional:
                       session (str) - "PRE_MARKET, REGULAR, AFTER_MARKET
-                      interval (str) - "YTD" or "-1W" etc.
-                      date_asof (str) - "YYYY-MM-DD" default is the most recent timestamp
+                      date_from (str) - "YYYY-MM-DD"
+                      date_to (str) - "YYYY-MM-DD" default is the most recent timestamp
                       max_results (int) - default 10
                       market_cap_gt (str) - market cap greater than "1b" etc
                       market_cap_lt (str) - market cap less than "1b" etc
@@ -1174,15 +1174,15 @@ class Benzinga:
             screener_query = "%s%s%s%s"% (market_cap_greater, marketcap_less, close_greater,sector)
         params = {
             "apikey": self.token,
-            "from": interval,
-            "to": date_asof,
+            "from": date_from,
+            "to": date_to,
             "session": session,
             "screenerQuery": screener_query,
             "maxResults": max_results
         }
         self.param_initiate.movers_check(params)
         try:
-            movers_url = self.__url_call__("movers")
+            movers_url = self._url_call("movers")
             movers = requests.get(movers_url, headers=self.headers, params=params)
             if movers.status_code == 401:
                 raise TokenAuthenticationError

--- a/build/lib/benzinga/news_data.py
+++ b/build/lib/benzinga/news_data.py
@@ -11,10 +11,10 @@ class News:
         self.headers = {'accept': 'application/json'}
         self.url_dict = {"API V2": "http://api.benzinga.com/api/v2/"}
 
-        self.__token_check__(self.token)
+        self._token_check(self.token)
         self.param_initiate = param_check.Param_Check()
 
-    def __token_check__(self, api_token):
+    def _token_check(self, api_token):
         """Private Method: Token check is a private method that does a basic check for whether the api token has
                access to the fundamentals and/or calendar data. Different tokens have access to different endpoints.
                Disregard the error if your request is fullfilled but the token authentication error is raised.
@@ -26,14 +26,14 @@ class News:
                 Token authentication error if token is invalid."""
         params = {'token': api_token}
         try:
-            sample_url = self.__url_call__("news")
+            sample_url = self._url_call("news")
             sample = requests.get(sample_url, headers= self.headers, params=params)
             if sample.status_code == 401:
                 raise TokenAuthenticationError
         except TokenAuthenticationError as t:
             raise AccessDeniedError
 
-    def __url_call__(self, resource, sub_resource=""):
+    def _url_call(self, resource, sub_resource=""):
         """Private Method: URL Call is used to take input from the public methods and return the appropriate url format
                 for the endpoint. For example, the resource is calendar and the subresource might be ratings. The correct
                 url endpoint call is created by using these two.
@@ -94,7 +94,7 @@ class News:
         }
         self.param_initiate.news_check(params)
         try:
-            news_url = self.__url_call__("news")
+            news_url = self._url_call("news")
             news = requests.get(news_url, headers=self.headers, params=params)
             if news.status_code == 401:
                 raise TokenAuthenticationError
@@ -124,7 +124,7 @@ class News:
         }
         self.param_initiate.news_check(params)
         try:
-            top_news_url = self.__url_call__("news-top-stories")
+            top_news_url = self._url_call("news-top-stories")
             top_news = requests.get(top_news_url, headers=self.headers, params=params)
             if top_news.status_code == 401:
                 raise TokenAuthenticationError
@@ -173,7 +173,7 @@ class News:
         }
         self.param_initiate.news_check(params)
         try:
-            channels_url = self.__url_call__("channels")
+            channels_url = self._url_call("channels")
             channels = requests.get(channels_url, headers=self.headers, params=params)
             if channels.status_code == 401:
                 raise TokenAuthenticationError
@@ -211,8 +211,8 @@ class News:
         }
         self.param_initiate.quantified_news_check(params)
         try:
-            quantnews_url = self.__url_call__("newsquantified")
-            quantnews = requests.get(quantnews_url, headers=self.headers, params=params)
+            quantnews_url = self._url_call("newsquantified")
+            Nquantnews = requests.get(quantnews_url, headers=self.headers, params=params)
             if quantnews.status_code == 401:
                 raise TokenAuthenticationError
         except requests.exceptions.RequestException:

--- a/build/lib/benzinga/param_check.py
+++ b/build/lib/benzinga/param_check.py
@@ -8,7 +8,7 @@ class Param_Check:
         self.nonetype = "NoneType"
         self.float = "float"
 
-    def __para_type_matching__(self, param_metadata, para_dict):
+    def _para_type_matching(self, param_metadata, para_dict):
         for param, value in para_dict.items():
             if (type(value).__name__ != param_metadata[param]) and (type(value).__name__ != self.nonetype):
                 raise IncorrectParameterEntry("Parameter Type for %s doesn't match: Correct Type: %s. " 
@@ -34,7 +34,7 @@ class Param_Check:
             "parameters[eps_surprise_percent]": self.stri,
             "parameters[revenue_surprise_percent]": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def fundamentals_check(self, dict):
         param_type = {
@@ -47,7 +47,7 @@ class Param_Check:
             "period": self.stri,
             "reportType": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def delayed_quote_check(self, dict):
         param_type = {
@@ -56,7 +56,7 @@ class Param_Check:
             "isin": self.stri,
             "cik": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def logos_check(self, dict):
         param_type = {
@@ -64,7 +64,7 @@ class Param_Check:
             "symbols": self.stri,
             "filters": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def instruments_check(self, dict):
         param_type = {
@@ -77,7 +77,7 @@ class Param_Check:
             "sortfield": self.stri,
             "sortdir": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def security_check(self, dict):
         param_type = {
@@ -85,7 +85,7 @@ class Param_Check:
             "symbol": self.stri,
             "cusip": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def charts_check(self, dict):
         param_type = {
@@ -96,14 +96,14 @@ class Param_Check:
             "interval": self.stri,
             "session": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def ticker_check(self, dict):
         param_type = {
             "apikey": self.stri,
             "symbols": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
     def autocomplete_check(self, dict):
         param_type = {
             "token": self.stri,
@@ -113,14 +113,14 @@ class Param_Check:
             "exchanges": self.stri,
             "types": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def batchhistory_check(self, dict):
         param_type = {
             "apikey": self.stri,
             "symbol": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def news_check(self, dict):
         param_type = {
@@ -140,7 +140,7 @@ class Param_Check:
             "limit": self.inte,
             "channel": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def quantified_news_check(self, dict):
         param_type = {
@@ -154,7 +154,7 @@ class Param_Check:
             "symbols": self.stri,
             "apikey": self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
     def movers_check(self, dict):
         param_type = {
@@ -165,7 +165,7 @@ class Param_Check:
             "maxResults": self.stri,
             "screenerQuery":self.stri
         }
-        self.__para_type_matching__(param_type, dict)
+        self._para_type_matching(param_type, dict)
 
 
 


### PR DESCRIPTION
From https://www.python.org/dev/peps/pep-0008/#descriptive-naming-styles

> __double_leading_and_trailing_underscore__: "magic" objects or attributes that live in user-controlled namespaces. E.g. __init__, __import__ or __file__. Never invent such names; only use them as documented.

I've properly formatted them using the '_name' format instead.

>_single_leading_underscore: weak "internal use" indicator. E.g. from M import * does not import objects whose names start with an underscore.

I refactored using search and replace in Vim, but it may be desirable to double check for anything I might have missed.